### PR TITLE
fix: let API wait until DB has spun up

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+
+sleep 30 # let database spin up
 flask db upgrade
 flask run --host=0.0.0.0


### PR DESCRIPTION
There's no proper way to find out if the DB is accessible. It's not an elegant solution as it will let the API sleep for 30 seconds, even on Azure where the DB will always be accessible, but it should fix the local DB problems.