### PR TITLE
CM-682 Fixing CORS

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -5,6 +5,7 @@ from flask_jwt_extended import current_user
 from flask_jwt_extended import jwt_required
 from flask_jwt_extended import create_refresh_token
 from flask_jwt_extended import get_jwt_identity
+from flask_cors import cross_origin
 from app.subscribe.store_subscription_data import check_email
 
 from app.errors.errors import InvalidUsageError, DatabaseError, UnauthorizedError
@@ -24,6 +25,7 @@ Valid URLS to access the refresh endpoint are specified in app/__init__.py
 
 
 @bp.route("/login", methods=["POST"])
+@cross_origin()
 @auto.doc()
 def login():
     """
@@ -89,6 +91,7 @@ def refresh():
 
 
 @bp.route("/protected", methods=["GET"])
+@cross_origin()
 @jwt_required()
 def protected():
     """
@@ -102,6 +105,7 @@ def protected():
 
 
 @bp.route("/register", methods=["POST"])
+@cross_origin()
 def register():
     """
     Registration endpoint

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -2,15 +2,18 @@ from app import db
 from flask import jsonify
 from app.errors import bp
 from app.errors.errors import DatabaseError, AlreadyExistsError, CustomError
+from flask_cors import cross_origin
 
 
 @bp.app_errorhandler(CustomError)
+@cross_origin()
 def handle_custom_error(error):
     response = jsonify({"error": error.message}), error.status_code
     return response
 
 
 @bp.app_errorhandler(DatabaseError)
+@cross_origin()
 def handle_database_error(error):
     db.session.rollback()
     response = jsonify({"error": error.message}), error.status_code
@@ -18,6 +21,7 @@ def handle_database_error(error):
 
 
 @bp.app_errorhandler(AlreadyExistsError)
+@cross_origin()
 def handle_existing_resource_error(error):
     response = (
         jsonify({"error": error.message + " already exists in the database."}),

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -19,6 +19,7 @@ describe("User can login", () => {
       (response) => {
         expect(response.status).to.equal(200);
         expect(response.headers["content-type"]).to.equal("application/json");
+        expect(response.headers["access-control-allow-origin"]).to.equal("*");
         expect(response.body).to.be.a("object");
         expect(response.body).to.have.property("access_token");
         expect(response.body).to.have.property("user");

--- a/cypress/integration/registration.spec.js
+++ b/cypress/integration/registration.spec.js
@@ -22,6 +22,7 @@ describe("User Registration", () => {
       (response) => {
         expect(response.status).to.equal(201);
         expect(response.headers["content-type"]).to.equal("application/json");
+        expect(response.headers["access-control-allow-origin"]).to.equal("*");
         expect(response.body).to.be.a("object");
         expect(response.body).to.have.property("message");
         expect(response.body.message).to.satisfy(function (s) {


### PR DESCRIPTION
Fixing missing CORS wrappers for security endpoints (excluding /refresh which needs restricted CORS).

Added test for login and register to ensure CORS present.

@y-himanen You don't need to review this, but I'd like the cross_origin() wrapper to be on your radar for all future endpoints/errors. This wrapper basically says any website is allowed to make a request to that resource. Without it, Nick will not be able to access the resource.