### PR TITLE
adding error logger

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import os
 from app import models
 from flask import Flask
 from datetime import datetime
@@ -9,6 +10,8 @@ from flask_jwt_extended import create_access_token
 from flask_jwt_extended import get_jwt
 from flask_jwt_extended import get_jwt_identity
 from flask_jwt_extended import set_access_cookies
+import logging
+from logging.handlers import RotatingFileHandler
 
 from config import DevelopmentConfig
 
@@ -45,6 +48,20 @@ def create_app(config_class=DevelopmentConfig):
         },
         supports_credentials=True,
     )
+
+    # Error Logger Outputs to Logs Directory
+
+    if not os.path.exists('logs'):
+        os.mkdir('logs')
+    file_handler = RotatingFileHandler('logs/cm_error.log', maxBytes=10240,
+                                       backupCount=10)
+    file_handler.setFormatter(logging.Formatter(
+        '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'))
+    file_handler.setLevel(logging.INFO)
+    app.logger.addHandler(file_handler)
+
+    app.logger.setLevel(logging.INFO)
+    app.logger.info('ClimateMind Startup')
 
     with app.app_context():
 

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -1,9 +1,10 @@
+import logging
+from logging.handlers import RotatingFileHandler
 from app import db
 from flask import jsonify
 from app.errors import bp
 from app.errors.errors import DatabaseError, AlreadyExistsError, CustomError
 from flask_cors import cross_origin
-
 
 @bp.app_errorhandler(CustomError)
 @cross_origin()


### PR DESCRIPTION
This is a simple error logger for Flask. You can see some basic info that will be logged to the /logs directory upon app startup.

At the moment, our application is not configured correctly. We are using with app.app_context() in the main __init__.py file and this is preventing the logger from accessing the actual errors of the application. I need to update the main app in the near future to not use this app context.

This PR is good to go for now.