### PR TITLE
CM-1038 alignment feed bug and logic fix

### DIFF
--- a/app/alignment/utils.py
+++ b/app/alignment/utils.py
@@ -634,8 +634,11 @@ def sort_aligned_effects_by_user_b_values(aligned_effects, user_b_quiz_uuid):
     """
     G = current_app.config["G"].copy()
 
-
-    user_b_scores = db.session.query(Scores).filter(Scores.quiz_uuid == user_b_quiz_uuid).one_or_none()
+    user_b_scores = (
+        db.session.query(Scores)
+        .filter(Scores.quiz_uuid == user_b_quiz_uuid)
+        .one_or_none()
+    )
 
     sorted_aligned_effects = dict()
 
@@ -654,11 +657,10 @@ def sort_aligned_effects_by_user_b_values(aligned_effects, user_b_quiz_uuid):
         ]
     )
 
-    #TO DO: there should be some map mapping node names to iri so that the scoring can go straight to the right node and not have to check the other nodes. 
+    # TO DO: there should be some map mapping node names to iri so that the scoring can go straight to the right node and not have to check the other nodes.
 
-    #TO DO: this scoring procedure should not be copied pasted from the user a personal climate feed scoring code, rather it should call those scoring functions so there aren't redundances in the code!
+    # TO DO: this scoring procedure should not be copied pasted from the user a personal climate feed scoring code, rather it should call those scoring functions so there aren't redundances in the code!
     modified_user_b_scores = np.square(user_b_scores)
-
 
     for aligned_effect in aligned_effects:
         for node in G.nodes:

--- a/app/alignment/utils.py
+++ b/app/alignment/utils.py
@@ -629,7 +629,7 @@ def sort_aligned_effects_by_user_b_values(aligned_effects, user_b_quiz_uuid):
 
     Returns
     ==========
-    sorted_aligned_effects - a dictionary of IRIs and dot products for the aligned effects and user b's personal value scores
+    sorted_aligned_effects - a list of topic IRIs (n_nodes long) that are top scoring effects based on dot products for the aligned effects and user b's personal value scores. Ordered from highest scoring first, to lower scoring. Scoring procedure used copies that used to create User A's personal climate feed.
 
     """
     G = current_app.config["G"].copy()

--- a/app/alignment/utils.py
+++ b/app/alignment/utils.py
@@ -619,28 +619,23 @@ def transform_aligned_scores(scores_array):
     return transformed_aligned_scores
 
 
-def sort_aligned_effects_by_user_b_values(aligned_effects, conversation_uuid):
-    """Reorder the aligned effects for users a and b according to user b's personal value scores.
+def sort_aligned_effects_by_user_b_values(aligned_effects, user_b_quiz_uuid):
+    """Reorder the top n=3 aligned effects for users a and b according to user b's personal value scores.
 
     Parameters
     ==========
-    aligned_effects - a list of IRIs for aligned effects ordered using the dot product of the users' aligned scores and the effects personal value associations
-    conversation_uuid (UUID) - the uuid for the conversation between user a and b
+    aligned_effects - a list of IRIs for aligned effects ordered using the dot product of the users' aligned scores and the effects personal value associations. These are just the n=3 top scoring effects.
+    user_b_quiz_uuid (UUID) - the uuid for the quiz scores for user b
 
     Returns
     ==========
     sorted_aligned_effects - a dictionary of IRIs and dot products for the aligned effects and user b's personal value scores
 
     """
-
     G = current_app.config["G"].copy()
 
-    user_b_journey, user_b_scores = (
-        db.session.query(UserBJourney, Scores)
-        .join(Scores, Scores.quiz_uuid == UserBJourney.quiz_uuid)
-        .filter(UserBJourney.conversation_uuid == conversation_uuid)
-        .one_or_none()
-    )
+
+    user_b_scores = db.session.query(Scores).filter(Scores.quiz_uuid == user_b_quiz_uuid).one_or_none()
 
     sorted_aligned_effects = dict()
 
@@ -659,7 +654,11 @@ def sort_aligned_effects_by_user_b_values(aligned_effects, conversation_uuid):
         ]
     )
 
+    #TO DO: there should be some map mapping node names to iri so that the scoring can go straight to the right node and not have to check the other nodes. 
+
+    #TO DO: this scoring procedure should not be copied pasted from the user a personal climate feed scoring code, rather it should call those scoring functions so there aren't redundances in the code!
     modified_user_b_scores = np.square(user_b_scores)
+
 
     for aligned_effect in aligned_effects:
         for node in G.nodes:
@@ -683,4 +682,6 @@ def sort_aligned_effects_by_user_b_values(aligned_effects, conversation_uuid):
         sorted(sorted_aligned_effects.items(), key=lambda x: x[1], reverse=True)
     )
 
-    return sorted_aligned_effects
+    sorted_aligned_effects_keys = list(sorted_aligned_effects.keys())
+
+    return sorted_aligned_effects_keys

--- a/app/feed/process_alignment_feed.py
+++ b/app/feed/process_alignment_feed.py
@@ -36,12 +36,15 @@ def create_alignment_feed(
     quiz_uuid (UUID) - user b quiz uuid to compare scores with user a scores
     alignment_feed_uuid (UUID) - uuid created when post alignment endpoint is used
     """
-    
 
-    #TO DO make a contant variable so 3 isn't hard coded as the number of effects to show to user B.
-    aligned_effects_sorted_by_shared_values = get_aligned_effects(alignment_scores_uuid, 3)
+    # TO DO make a contant variable so 3 isn't hard coded as the number of effects to show to user B.
+    aligned_effects_sorted_by_shared_values = get_aligned_effects(
+        alignment_scores_uuid, 3
+    )
 
-    sorted_aligned_effects = sort_aligned_effects_by_user_b_values(aligned_effects_sorted_by_shared_values, quiz_uuid)
+    sorted_aligned_effects = sort_aligned_effects_by_user_b_values(
+        aligned_effects_sorted_by_shared_values, quiz_uuid
+    )
 
     try:
         alignment_feed = AlignmentFeed()
@@ -125,7 +128,7 @@ def get_aligned_effects(alignment_scores_uuid, n_nodes):
     )
 
     aligned_effects_keys = list(aligned_effects.keys())
-    
+
     aligned_effects_top_keys = []
     if len(aligned_effects_keys) > n_nodes:
         aligned_effects_top_keys = aligned_effects_keys[0:n_nodes]

--- a/app/feed/process_alignment_feed.py
+++ b/app/feed/process_alignment_feed.py
@@ -36,16 +36,12 @@ def create_alignment_feed(
     quiz_uuid (UUID) - user b quiz uuid to compare scores with user a scores
     alignment_feed_uuid (UUID) - uuid created when post alignment endpoint is used
     """
+    
 
-    aligned_effects = list(get_aligned_effects(alignment_scores_uuid).keys())
+    #TO DO make a contant variable so 3 isn't hard coded as the number of effects to show to user B.
+    aligned_effects_sorted_by_shared_values = get_aligned_effects(alignment_scores_uuid, 3)
 
-    sorted_aligned_effects = list(
-        sort_aligned_effects_by_user_b_values(aligned_effects, conversation_uuid).keys()
-    )
-
-    # TODO: delete this check after expansion of the ontology
-    while len(sorted_aligned_effects) < 3:
-        aligned_effects.append(sorted_aligned_effects[0])
+    sorted_aligned_effects = sort_aligned_effects_by_user_b_values(aligned_effects_sorted_by_shared_values, quiz_uuid)
 
     try:
         alignment_feed = AlignmentFeed()
@@ -71,7 +67,7 @@ def create_alignment_feed(
         )
 
 
-def get_aligned_effects(alignment_scores_uuid):
+def get_aligned_effects(alignment_scores_uuid, n_nodes):
     """
     Create a sorted dictionary of IRIs and dot products for impacts/effects from the ontology that are positively associated with the top aligned personal
     value for users A and B (calculated based on comparison of their quiz results).
@@ -79,6 +75,7 @@ def get_aligned_effects(alignment_scores_uuid):
     Parameters
     ==========
     alignment_scores_uuid (UUID) - the uuid for the aligned scores for users a and b
+    n_nodes (int) - the number of effect nodes to output that score the highest. Default is 3 impacts.
 
     Returns
     ==========
@@ -127,7 +124,20 @@ def get_aligned_effects(alignment_scores_uuid):
         sorted(aligned_effects.items(), key=lambda x: x[1], reverse=True)
     )
 
-    return aligned_effects
+    aligned_effects_keys = list(aligned_effects.keys())
+    
+    aligned_effects_top_keys = []
+    if len(aligned_effects_keys) > n_nodes:
+        aligned_effects_top_keys = aligned_effects_keys[0:n_nodes]
+    else:
+        aligned_effects_top_keys = aligned_effects_keys
+
+    # TODO: delete this check after expansion of the ontology. This repeats the topics until the list is n long as needed.
+    aligned_effects_key_extra = list(aligned_effects.keys())[1]
+    while len(aligned_effects_keys) < n_nodes:
+        aligned_effects_top_keys.append(aligned_effects_key_extra)
+
+    return aligned_effects_top_keys
 
 
 def assign_alignment_iris(alignment_feed, field_type, iris):

--- a/app/feed/process_alignment_feed.py
+++ b/app/feed/process_alignment_feed.py
@@ -82,7 +82,7 @@ def get_aligned_effects(alignment_scores_uuid, n_nodes):
 
     Returns
     ==========
-    aligned_effects - a sorted dictionary of effects positively associated with user a and b's top shared value
+    aligned_effects - a list of topic IRIs (n_nodes long) that are top scoring effects positively associated with user a and b's top shared value. Ordered from highest scoring first, to lower scoring.
     """
     aligned_effects = dict()
 


### PR DESCRIPTION
The bug was found and fixed. It had to do with checking for a value in the database that had not yet been written to the db. In addition, I fixed some missing logic that didn’t get caught during PR of CM-921. The top 3 shared topics are supposed to be ordered via version 1 scoring using user b’s scores, not topics with the shared personal value.

Lastly, the results are returned as lists instead of dictionaries since only iri are needed. This is minor, but necessary because if there are less than 3 topics possible, 1 topic needs to be repeated and if dictionaries are used then the topic can’t be repeated because dictionaries can’t have duplicate keys.