### PR TITLE
CM-1022 new UT added for feed.process_alignment_feed.get_aligned_effe…

### DIFF
--- a/app/errors/errors.py
+++ b/app/errors/errors.py
@@ -15,7 +15,11 @@ class InvalidUsageError(CustomError):
 
 
 class DatabaseError(CustomError):
-    status_code = 500
+    pass
+
+
+class OntologyError(CustomError):
+    pass
 
 
 class NotInDatabaseError(CustomError):

--- a/app/feed/constants.py
+++ b/app/feed/constants.py
@@ -1,0 +1,15 @@
+CONVERSATION_SOLUTION_NAME = "effective communication framing"
+POPULAR_SOLUTION_NAMES = {
+    "enact carbon tax policy (revenue neutral)",
+    "reducing food waste",
+    "composting",
+    "eating lower down the food-chain (plant-rich diets)",
+    "producing electricity via onshore wind turbines",
+    "using high-efficiency heat pumps",
+    "using improved clean cookstoves",
+    "producing electricity via distributed solar photovoltaics",
+    "making aviation more efficient",
+}
+POPULAR_SOLUTION_COUNT = 4
+UNPOPULAR_SOLUTION_COUNT = 2
+ALIGNMENT_EFFECTS_COUNT = 3

--- a/app/feed/process_alignment_feed.py
+++ b/app/feed/process_alignment_feed.py
@@ -87,12 +87,12 @@ def get_aligned_effects(alignment_scores_uuid: uuid.UUID, n_nodes: int) -> list:
     for node in G.nodes:
         current_node = G.nodes[node]
 
-        is_risky = "risk" in current_node["all classes"]
+        is_risk_class = "risk" in current_node["all classes"]
         is_test_ontology = "test ontology" in current_node["all classes"]
         node_without_personal_values = all(
             [value == None for value in current_node["personal_values_10"]]
         )
-        if is_risky and is_test_ontology and not node_without_personal_values:
+        if is_risk_class and is_test_ontology and not node_without_personal_values:
             associated_personal_values = map_associated_personal_values(
                 current_node["personal_values_10"]
             )
@@ -110,7 +110,6 @@ def get_aligned_effects(alignment_scores_uuid: uuid.UUID, n_nodes: int) -> list:
                     transformed_aligned_scores, adjusted_node_value_associations_10
                 )
                 aligned_effects[get_node_id(current_node)] = dot_product
-
     if aligned_effects:
         aligned_effects = dict(
             sorted(aligned_effects.items(), key=lambda x: x[1], reverse=True)

--- a/app/feed/tests/test_process_alignment_feed.py
+++ b/app/feed/tests/test_process_alignment_feed.py
@@ -1,13 +1,21 @@
-from app.network_x_tools.network_x_utils import network_x_utils
+import pytest
+from flask import current_app
 
+from app.factories import AlignmentScoresFactory
 from app.feed.process_alignment_feed import (
+    get_aligned_effects,
     get_default_solutions_iris,
     get_solution_nodes,
+)
+from app.feed.constants import (
     CONVERSATION_SOLUTION_NAME,
     POPULAR_SOLUTION_NAMES,
     POPULAR_SOLUTION_COUNT,
     UNPOPULAR_SOLUTION_COUNT,
+    ALIGNMENT_EFFECTS_COUNT,
 )
+from app.network_x_tools.network_x_utils import network_x_utils
+from app.personal_values.enums import PersonalValue
 
 
 def test_get_default_solutions_iris():
@@ -51,3 +59,16 @@ def test_get_default_solutions_iris():
     assert (
         len(unpopular_iris) == UNPOPULAR_SOLUTION_COUNT
     ), "Result contain proper unpopular solution count"
+
+
+@pytest.mark.ontology
+@pytest.mark.parametrize("personal_value", [v.key for v in PersonalValue])
+def test_get_aligned_effects(personal_value):
+    alignment_score_arguments = {f"{personal_value}_alignment": 0.99}
+    alignment_score = AlignmentScoresFactory(**alignment_score_arguments)
+
+    aligned_effects = get_aligned_effects(
+        alignment_score.alignment_scores_uuid,
+        ALIGNMENT_EFFECTS_COUNT,
+    )
+    assert len(aligned_effects) == ALIGNMENT_EFFECTS_COUNT

--- a/app/network_x_tools/tests/test_x_processor.py
+++ b/app/network_x_tools/tests/test_x_processor.py
@@ -4,12 +4,14 @@ from networkx import DiGraph
 from app.network_x_tools.network_x_processor import network_x_processor
 
 
+@pytest.mark.ontology
 def test_get_graph_type():
     nx_processor = network_x_processor()
     graph = nx_processor.get_graph()
     assert type(graph) == DiGraph
 
 
+@pytest.mark.ontology
 def test_get_graph_missing_file():
     nx_processor = network_x_processor()
     nx_processor.graph_file = "missing.gpickle"

--- a/app/personal_values/utils.py
+++ b/app/personal_values/utils.py
@@ -3,6 +3,7 @@ from json import load
 from flask import jsonify
 
 
+# TODO: replace with PersonalValue enum if possible
 def get_value_descriptions_map():
     """Get a name->description dict for all values."""
     try:

--- a/app/scoring/process_alignment_scores.py
+++ b/app/scoring/process_alignment_scores.py
@@ -37,6 +37,8 @@ def create_alignment_scores(conversation_uuid, quiz_uuid, alignment_scores_uuid)
 
         alignment_scores = AlignmentScores()
         alignment_scores.alignment_scores_uuid = alignment_scores_uuid
+        # FIXME: could be a problem if you will change personal values names
+        #  create mapping in PersonalValue
         for name in value_names:
             setattr(alignment_scores, name + "_alignment", alignment_map[name])
         alignment_scores.top_match_value = max_name

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,5 @@ testpaths = app
 addopts = --strict-markers
 markers =
     integration: testing API endpoints.
+    ontology: testing ontology stored in Climate_Mind_DiGraph.gpickle.
 mocked-sessions=app.extensions.db.session


### PR DESCRIPTION
…cts plus refactoring

- constants moved to the separate file inside the feed module (could be moved to the config if any will be used somewhere else)
- factories updated
- new ontology pytest mark was added ( use `pytest -m ontology` to run all ontology tests) 
- new ontology error added

@rodriguesk The `IndexError` you've sent me was caused by an invalid ontology. There's no suitable nodes for the `self-direction` personal value. 