### PR TITLE
Cm 939 backend conversation edit endpoint

### DIFF
--- a/app/alignment/routes.py
+++ b/app/alignment/routes.py
@@ -38,13 +38,13 @@ def post_alignment_uuid():
     session_uuid = validate_uuid(session_uuid, uuidType.SESSION)
     check_uuid_in_db(session_uuid, uuidType.SESSION)
 
-    r = request.get_json(force=True, silent=True)
+    request_data = request.get_json(force=True, silent=True)
 
-    conversation_uuid = r.get("conversationId")
-    quiz_uuid = r.get("quizId")
-
+    conversation_uuid = request_data.get("conversationId")
     conversation_uuid = validate_uuid(conversation_uuid, uuidType.CONVERSATION)
     check_uuid_in_db(conversation_uuid, uuidType.CONVERSATION)
+
+    quiz_uuid = request_data.get("quizId")
     quiz_uuid = validate_uuid(quiz_uuid, uuidType.QUIZ)
     check_uuid_in_db(quiz_uuid, uuidType.QUIZ)
 

--- a/app/common/schemas.py
+++ b/app/common/schemas.py
@@ -1,0 +1,29 @@
+from flask import current_app
+from flask_marshmallow import Marshmallow
+from marshmallow import Schema
+
+from app.errors.errors import InvalidUsageError
+
+ma = Marshmallow(current_app)
+
+
+def camelcase(s):
+    parts = iter(s.split("_"))
+    return next(parts) + "".join(i.title() for i in parts)
+
+
+class CamelCaseSchema:
+    """Schema that uses camel-case for its external representation
+    and snake-case for its internal representation.
+    """
+
+    def on_bind_field(self, field_name, field_obj):
+        field_obj.data_key = camelcase(field_obj.data_key or field_name)
+
+
+def validate_schema_field(schema: Schema, field_name: str, value: str) -> bool:
+    errors = schema.validate({field_name: value}, partial=True)
+    if errors:
+        raise InvalidUsageError(message=f"{field_name}: {errors[field_name]}")
+    else:
+        return True

--- a/app/conversations/enums.py
+++ b/app/conversations/enums.py
@@ -1,0 +1,15 @@
+from enum import IntEnum
+
+
+class ConversationStatus(IntEnum):
+    """
+    Conversation status is used to identify where a user is
+    in their journey to communicate with other users they invite.
+
+    This enum should not be modified unless the frontend is involved in the change.
+    """
+
+    Invited = 0
+    Visited = 1
+    QuizCompleted = 2
+    ConversationCompleted = 3

--- a/app/conversations/schemas.py
+++ b/app/conversations/schemas.py
@@ -1,0 +1,17 @@
+from marshmallow import fields, validate
+
+from app.common.schemas import CamelCaseSchema, ma
+from app.conversations.enums import ConversationStatus
+from app.models import Conversations
+
+
+class ConversationEditSchema(CamelCaseSchema, ma.SQLAlchemySchema):
+    class Meta:
+        model = Conversations
+        load_instance = True
+
+    conversation_id = ma.auto_field("conversation_uuid")
+    receiver_name = ma.auto_field()
+    conversation_status = fields.Integer(validate=validate.OneOf(
+        [s.value for s in ConversationStatus]
+    ))

--- a/app/conversations/schemas.py
+++ b/app/conversations/schemas.py
@@ -12,6 +12,6 @@ class ConversationEditSchema(CamelCaseSchema, ma.SQLAlchemySchema):
 
     conversation_id = ma.auto_field("conversation_uuid")
     receiver_name = ma.auto_field()
-    conversation_status = fields.Integer(validate=validate.OneOf(
-        [s.value for s in ConversationStatus]
-    ))
+    conversation_status = fields.Integer(
+        validate=validate.OneOf([s.value for s in ConversationStatus])
+    )

--- a/app/conversations/tests/test_conversations_routes.py
+++ b/app/conversations/tests/test_conversations_routes.py
@@ -1,0 +1,166 @@
+import random
+import typing
+import uuid
+
+import pytest
+from flask import url_for
+from flask.testing import FlaskClient
+from mock import mock
+
+from app.conversations.enums import ConversationStatus
+from app.factories import ConversationsFactory, faker
+from app.models import Conversations, Users
+
+RANDOM_CONVERSATION_STATUS = random.choice(list([s.value for s in ConversationStatus]))
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "request_data,status_code",
+    [
+        ({"receiverName": faker.name()}, 200),
+        ({"conversationStatus": RANDOM_CONVERSATION_STATUS}, 200),
+        ({"conversationStatus": 999}, 422),  # beyond enum
+        ({"conversationStatus": "wrong type"}, 422),  # type error
+        (
+            {
+                "receiverName": faker.name(),
+                "conversationStatus": RANDOM_CONVERSATION_STATUS,
+            },
+            200,
+        ),
+        ({"receiver_name": faker.name()}, 422),  # name error
+        ({"userBShareConsent": faker.pybool()}, 422),  # user A cannot change consent
+    ],
+)
+def test_edit_conversation_request_data(
+    request_data, status_code, client_with_user_and_header, accept_json
+):
+    client, user, session_header = client_with_user_and_header
+
+    expected_response_keys = {
+        "conversationId",
+        "conversationStatus",
+        "receiverName",
+    }
+
+    conversation = ConversationsFactory(sender_user=user)
+    assert Conversations.query.count() == 1, "Make sure we have a single Conversation"
+
+    with mock.patch("flask_jwt_extended.utils.get_current_user", return_value=user):
+        url = url_for(
+            "conversations.edit_conversation",
+            conversation_uuid=conversation.conversation_uuid,
+        )
+
+        response = client.put(
+            url,
+            headers=session_header + accept_json,
+            json=request_data,
+        )
+
+        assert response.status_code == status_code, str(response.json)
+
+        response_json_keys = response.json.keys()
+        if response.status_code == 200:
+            assert set(response_json_keys) == expected_response_keys
+            for request_key, request_value in request_data.items():
+                assert response.json[request_key] == request_value, "All values updated"
+        else:
+            assert set(response_json_keys) != expected_response_keys
+            assert set(response_json_keys) == set(request_data.keys()), "Errors only"
+
+    assert Conversations.query.count() == 1, "Conversations count kept the same."
+
+
+def emulate_test_edit_conversation_request_with_error(
+    client: FlaskClient,
+    user: Users,
+    headers: list,
+    test_uuid: typing.Union[uuid.UUID, str],
+):
+    with mock.patch("flask_jwt_extended.utils.get_current_user", return_value=user):
+        url = url_for(
+            "conversations.edit_conversation",
+            conversation_uuid=test_uuid,
+        )
+        response = client.put(
+            url,
+            json={"receiver_name": "unbeliever"},
+            headers=headers,
+        )
+        return response
+
+
+@pytest.mark.integration
+def test_edit_conversation_request_without_session(
+    client_with_user_and_header, accept_json
+):
+    client, user, _ = client_with_user_and_header
+    conversation = ConversationsFactory(sender_user=user)
+
+    response = emulate_test_edit_conversation_request_with_error(
+        client, user, accept_json, conversation.conversation_uuid
+    )
+
+    assert response.status_code == 400, "Missing session header"
+
+
+@pytest.mark.integration
+def test_edit_conversation_request_invalid_uuid(
+    client_with_user_and_header, accept_json
+):
+    client, user, session_header = client_with_user_and_header
+
+    headers = session_header + accept_json
+    response = emulate_test_edit_conversation_request_with_error(
+        client, user, headers, "invalid uuid"
+    )
+
+    assert response.status_code == 400, "Invalid convo UUID provided"
+
+
+@pytest.mark.integration
+def test_edit_conversation_request_not_found(client_with_user_and_header, accept_json):
+    client, user, session_header = client_with_user_and_header
+    conversation = ConversationsFactory(sender_user=user)
+    wrong_convo_uuid = faker.uuid4()
+    assert conversation.conversation_uuid != wrong_convo_uuid
+
+    headers = session_header + accept_json
+    response = emulate_test_edit_conversation_request_with_error(
+        client, user, headers, wrong_convo_uuid
+    )
+
+    assert response.status_code == 404, "Convo with this UUID should not be found"
+
+
+@pytest.mark.integration
+def test_edit_conversation_request_forbidden(client_with_user_and_header, accept_json):
+    client, user, session_header = client_with_user_and_header
+    conversation = ConversationsFactory()
+    assert user.user_uuid != conversation.sender_user_uuid, "Users should be different"
+
+    headers = session_header + accept_json
+    response = emulate_test_edit_conversation_request_with_error(
+        client, user, headers, conversation.conversation_uuid
+    )
+
+    assert response.status_code == 403, "Convo sender_user mismatch"
+
+
+@pytest.mark.integration
+def test_edit_conversation_request_unauthorized(
+    client_with_user_and_header, accept_json
+):
+    client, user, session_header = client_with_user_and_header
+    client.delete_cookie("localhost", "access_token")
+
+    conversation = ConversationsFactory(sender_user=user)
+
+    headers = session_header + accept_json
+    response = emulate_test_edit_conversation_request_with_error(
+        client, user, headers, conversation.conversation_uuid
+    )
+
+    assert response.status_code == 401, "Unauthorized access forbidden"

--- a/app/conversations/utils.py
+++ b/app/conversations/utils.py
@@ -1,7 +1,7 @@
 from flask import current_app
 
-from email import message
-
+from app.conversations.enums import ConversationStatus
+from app import db
 from app.errors.errors import DatabaseError
 from app.models import Conversations, UserBJourney, Users, EffectChoice, SolutionChoice
 import app.conversations.routes as con
@@ -97,9 +97,9 @@ def update_consent_choice(conversation_uuid, consent_choice, session_uuid):
         conversation.user_b_share_consent = user_b_journey.consent = consent_choice
 
         if consent_choice:
-            conversation.conversation_status = con.ConversationStatus.QuizCompleted
+            conversation.conversation_status = ConversationStatus.QuizCompleted
         else:
-            conversation.conversation_status = con.ConversationStatus.Visited
+            conversation.conversation_status = ConversationStatus.Visited
 
     except:
         raise DatabaseError(

--- a/app/errors/errors.py
+++ b/app/errors/errors.py
@@ -22,6 +22,10 @@ class OntologyError(CustomError):
     pass
 
 
+class ForbiddenError(CustomError):
+    status_code = 403
+
+
 class NotInDatabaseError(CustomError):
     status_code = 404
 

--- a/app/factories.py
+++ b/app/factories.py
@@ -5,7 +5,7 @@ import factory
 from faker import Factory as FakerFactory
 from werkzeug.security import generate_password_hash
 
-from app.conversations.routes import ConversationStatus
+from app.conversations.enums import ConversationStatus
 from app.models import (
     Users,
     Sessions,

--- a/app/feed/process_alignment_feed.py
+++ b/app/feed/process_alignment_feed.py
@@ -50,7 +50,7 @@ def create_alignment_feed(
             temporary_solutions_iris,
         )
         db.session.add(alignment_feed)
-        db.session.commit
+        db.session.commit()
     except:
         raise DatabaseError(
             message="An error occurred while adding the alignment feed to the database."

--- a/app/feed/tests/test_process_alignment_feed.py
+++ b/app/feed/tests/test_process_alignment_feed.py
@@ -34,7 +34,7 @@ def test_get_default_solutions_iris():
     )
     assert (
         len(result_solution_iris) == total_solutions_count
-    ), f"Total solutions cound should be {total_solutions_count}"
+    ), f"Total solutions count should be {total_solutions_count}"
 
     first_iri_in_result = result_solution_iris[0]
     assert (

--- a/app/scoring/process_alignment_scores.py
+++ b/app/scoring/process_alignment_scores.py
@@ -77,7 +77,7 @@ def get_sorted_alignment_map(alignment_map):
     return sorted(alignment_map.items(), key=lambda x: -x[1])
 
 
-def get_max(alignment_map):
+def get_max(alignment_map: dict) -> tuple:
     """Find the max alignment score with its personal value name."""
     return sorted(alignment_map.items(), key=lambda pair: -pair[1])[0]
 

--- a/app/scoring/tests/test_process_alignment_scores.py
+++ b/app/scoring/tests/test_process_alignment_scores.py
@@ -1,8 +1,10 @@
 import pytest
 
-import app.scoring.process_alignment_scores as pas
-
-### Example data was taken from https://docs.google.com/document/d/1cqmBvNd8sWV1d6EvmTLgp6DlR3h1RVgW7pNDGgmV_k4/edit
+from app.scoring.process_alignment_scores import (
+    get_rank_map,
+    get_alignment_map,
+    get_max,
+)
 from app.personal_values.enums import PersonalValue
 
 
@@ -21,7 +23,7 @@ def test_get_rank_map():
     }
     score_map = {name: data[0] for (name, data) in data_map.items()}
     expected_rank_map = {name: data[1] for (name, data) in data_map.items()}
-    actual_rank_map = pas.get_rank_map(score_map)
+    actual_rank_map = get_rank_map(score_map)
     assert (
         actual_rank_map == expected_rank_map
     ), "Rank map does not have expected values."
@@ -43,7 +45,7 @@ def test_get_alignment_map():
     userA_rank_map = {name: data[0] for (name, data) in data_map.items()}
     userB_rank_map = {name: data[1] for (name, data) in data_map.items()}
     expected_alignment_map = {name: data[2] for (name, data) in data_map.items()}
-    actual_raw_alignment_map = pas.get_alignment_map(userA_rank_map, userB_rank_map)
+    actual_raw_alignment_map = get_alignment_map(userA_rank_map, userB_rank_map)
     actual_alignment_map = {
         name: round(value, 3) for (name, value) in actual_raw_alignment_map.items()
     }
@@ -65,7 +67,7 @@ def test_get_max():
         PersonalValue.TRADITION.key: 0.572,
         PersonalValue.HEDONISM.key: 0.000,
     }
+    expected_max = (PersonalValue.BENEVOLENCE.key, 0.853)
 
-    expected_max = ("benevolence", 0.853)
-    actual_max = pas.get_max(data_map)
+    actual_max = get_max(data_map)
     assert actual_max == expected_max, "The correct max value was not chosen."

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,6 @@ addopts = --strict-markers
 markers =
     integration: testing API endpoints.
     ontology: testing ontology stored in Climate_Mind_DiGraph.gpickle.
-mocked-sessions=app.extensions.db.session
+mocked-sessions=
+    app.extensions.db.session
+    marshmallow_sqlalchemy.load_instance_mixin.LoadInstanceMixin.Schema.session

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ Flask-Compress==1.5.0
 Flask-Cors==3.0.9
 Flask-JWT-Extended==4.0.2
 Flask-Login==0.5.0
+flask-marshmallow==0.14.0
 Flask-Migrate==2.5.3
 Flask-SQLAlchemy==2.4.4
 Flask-Selfdoc==1.2.3
@@ -48,6 +49,7 @@ Mako==1.1.3
 MarkupSafe==1.1.1
 matplotlib==3.3.0
 marshmallow==3.8.0
+marshmallow-sqlalchemy==0.28.0
 modulegraph==0.10.4
 more-itertools==8.4.0
 networkx==2.4


### PR DESCRIPTION
I've created an endpoint https://climatemind.stoplight.io/docs/climatemind-backend/branches/develop/a79c424fa467d-single-conversation-get (docs will be updated tomorrow) 

I think it's essential to bring a [serialization](https://www.django-rest-framework.org/api-guide/serializers/) concept to the project. In a nutshell, it should do almost all the work from our `utils.py` files including:
- processing user input and validation (e.g. validate_uuid)
- preparing response based on DB objects. 

I've noticed we already have a great dependency [marshmallow](https://github.com/marshmallow-code/marshmallow) in the [project](https://github.com/ClimateMind/climatemind-backend/blob/develop/requirements.txt#L50).  but we don't use it for some reason. 
To make it easier to use with flask I've added a couple of more dependencies 
- https://marshmallow-sqlalchemy.readthedocs.io/en/latest/
- https://flask-marshmallow.readthedocs.io/en/latest/
and made it work with PyTest