### PR TITLE
CM-1063 test & prod migrations to use path variable instead of hard coded

### DIFF
--- a/docker/services/web/prod/entrypoint.prod.sh
+++ b/docker/services/web/prod/entrypoint.prod.sh
@@ -3,6 +3,8 @@
 echo "sleeping entrypoint"
 sleep 45
 
-flask db upgrade
+BASEDIR="$(dirname "${BASH_SOURCE[0]}")"
+
+flask db upgrade -d $BASEDIR/migrations
 
 gunicorn --bind 0.0.0.0:5000 climatemind:app


### PR DESCRIPTION
Changed to use path variable instead of hardcoding.