### PR TITLE
CM-1069: sessions and users

### DIFF
--- a/app/scoring/process_scores.py
+++ b/app/scoring/process_scores.py
@@ -88,13 +88,13 @@ class ProcessScores:
             user_scores.scores_created_timestamp = datetime.datetime.now(timezone.utc)
             user_scores.session_uuid = session_uuid
 
-            if user_uuid:
-                user_scores.user_uuid = user_uuid
-                user = Users.query.filter_by(user_uuid=user_uuid).first()
-                user.quiz_uuid = self.value_scores["quiz_uuid"]
-
             db.session.add(user_scores)
             db.session.commit()
+
+            if user_uuid:
+                user = Users.query.filter_by(user_uuid=user_uuid).first()
+                user.quiz_uuid = user_scores.quiz_uuid
+                db.session.commit()
 
         except:
             raise DatabaseError(

--- a/app/scoring/routes.py
+++ b/app/scoring/routes.py
@@ -67,10 +67,6 @@ def user_scores():
     quiz_uuid = uuid.uuid4()
     value_scores["quiz_uuid"] = quiz_uuid
 
-    user_uuid = None
-    if current_user:
-        user_uuid = current_user.user_uuid
-
     session_uuid = request.headers.get("X-Session-Id")
 
     if not session_uuid:
@@ -78,6 +74,10 @@ def user_scores():
 
     validate_uuid(session_uuid, uuidType.SESSION)
     check_uuid_in_db(session_uuid, uuidType.SESSION)
+
+    user_uuid = None
+    if current_user:
+        user_uuid = current_user.user_uuid
 
     process_scores.persist_scores(user_uuid, session_uuid)
 

--- a/climatemind.py
+++ b/climatemind.py
@@ -2,3 +2,12 @@ from app import create_app
 
 app = create_app()
 app.app_context().push()
+
+
+from flask import request
+from app.session.session_helpers import maybe_assign_session
+
+
+@app.before_request
+def before_request_hook():
+    maybe_assign_session(request)

--- a/conftest.py
+++ b/conftest.py
@@ -6,8 +6,17 @@ from app import create_app
 from app.extensions import db
 from config import TestingConfig, DevelopmentConfig
 
+from flask import request
+from app.session.session_helpers import maybe_assign_session
+
+
 app = create_app(TestingConfig)
 app.app_context().push()
+
+
+@app.before_request
+def before_request_hook():
+    maybe_assign_session(request)
 
 
 def pytest_configure():


### PR DESCRIPTION
* fixes bug in assigning quiz to session (not user)
* more generally, adds assign_session function and use it in routes if and only if the route has jwt_token and session_uuid (though not sure if this is the optimal criterion?)

