### PR TITLE
forgives blank values in Authorization field

### DIFF
--- a/app/session/session_helpers.py
+++ b/app/session/session_helpers.py
@@ -82,7 +82,11 @@ def maybe_assign_session(request):
         None or DatabaseError
     """
 
-    if "Authorization" in request.headers and "X-Session-Id" in request.headers:
+    if (
+        "Authorization" in request.headers
+        and "X-Session-Id" in request.headers
+        and request.headers["Authorization"] != ""
+    ):
 
         verify_jwt_in_request()
         user_uuid = get_jwt_identity()


### PR DESCRIPTION
A blank value in 'Authorizations' field of the header no longer triggers JWT validation in user B endpoints when session-id is also included.