### PR TITLE
Cm 1108 add quizid to get conversation

### DIFF
--- a/app/conversations/utils.py
+++ b/app/conversations/utils.py
@@ -43,13 +43,17 @@ def build_single_conversation_response(conversation_uuid):
     ).first_name
 
     if conversation.user_b_share_consent:
-        alignment_scores_uuid = (
+        user_b_journey = (
             db.session.query(UserBJourney)
             .filter_by(conversation_uuid=conversation_uuid)
             .one()
-        ).alignment_scores_uuid
+        )
+        alignment_scores_uuid = user_b_journey.alignment_scores_uuid
+        user_b_quiz_uuid = user_b_journey.quiz_uuid
+
     else:
         alignment_scores_uuid = None
+        user_b_quiz_uuid = None
 
     response = {
         "conversationId": conversation.conversation_uuid,
@@ -60,6 +64,7 @@ def build_single_conversation_response(conversation_uuid):
         },
         "userB": {
             "name": conversation.receiver_name,
+            "quizId": user_b_quiz_uuid,
         },
         "state": conversation.state,
         "userARating": conversation.user_a_rating,

--- a/app/static/Climate-Mind_bundled.yml
+++ b/app/static/Climate-Mind_bundled.yml
@@ -298,6 +298,8 @@ paths:
                       name:
                         type: string
                         minLength: 1
+                      quizId:
+                        type: string
                   state:
                     type: number
                     enum:
@@ -341,6 +343,7 @@ paths:
                       sessionId: 671e4949-a3e4-4844-b9d2-cd843f48f357
                     userB:
                       name: Bob
+                      quizId: 842a4949-a3e4-4914-c9d2-cd843f48f357
                     state: 2
                     consent: true
                     conversationTimestamp: 'Sun, 10 Oct 2021 18:35:02 GMT'
@@ -354,6 +357,7 @@ paths:
                       sessionId: 671e4949-a3e4-4844-b9d2-cd843f48f357
                     userB:
                       name: Bob
+                      quizId: null
                     state: 2
                     consent: false
                     conversationTimestamp: 'Sun, 10 Oct 2021 18:35:02 GMT'


### PR DESCRIPTION
Added quizId for user B to GET /conversation/{conversationId}. Analogously to the alignmentScoresId, the field is included in any case but set to null if consent=False.