### PR TITLE
fix: Removes Chokidar from Docker Compose files

### DIFF
--- a/docker/docker-compose.m1.yml
+++ b/docker/docker-compose.m1.yml
@@ -42,8 +42,6 @@ services:
       - api
     ports:
       - "3000:3000"
-    environment:
-      CHOKIDAR_USEPOLLING: true
     profiles:
       - webapp
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,8 +41,6 @@ services:
       - api
     ports:
       - "3000:3000"
-    environment:
-      CHOKIDAR_USEPOLLING: true
     profiles:
       - webapp
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,3 +47,4 @@ services:
 volumes:
   mssql_data:
     driver: local
+


### PR DESCRIPTION
### Detailed information:

Attempting to run Docker Compose is throwing an error:

```
ERROR: The Compose file './docker/docker-compose.yml' is invalid because:
services.webapp.environment.CHOKIDAR_USEPOLLING contains true, which is an invalid type, it should be a string, number, or a null
```

Since it seems that Chokidar is not being using at all, this commit removes it from the Docker Compose files.

### Closing issues: 

- Closes *#437*

### Test plan (required)

<!-- Check all steps below and mark completed -->

- [X] The PR contains new PyTest unit/integration tests for any function or functional added. 
- [ ] The PR changes existing PyTest unit/integration tests to keep all tests up to date.
- [X] The PR does not lead to degradation in unit test coverage.
- [X] Project parts affected by changes in this PR was tested manually on your local (using Postman or in any other way). List everything you've tested below:
  - This affects the containers deployed, and no functionality at all.

