### PR TITLE
#349 Fix local 429 errors by splitting host and checking if hostname is local

### DIFF
--- a/app/common/local.py
+++ b/app/common/local.py
@@ -11,10 +11,12 @@ def check_if_local() -> bool:
     local = False
 
     if os.environ.get("IS_LOCAL"):
+        request_hostname = request.host.split(":")[0]
         local = (
             request.remote_addr == "127.0.0.1"
+            or request_hostname == "127.0.0.1"
+            or request_hostname == "localhost"
             or os.environ.get("VPN")
-            or request.host == "localhost"
         )
 
     return local

--- a/app/common/tests/test_common_local.py
+++ b/app/common/tests/test_common_local.py
@@ -18,6 +18,12 @@ def test_check_if_local_on_local(mocked_env_get):
         assert check_if_local(), "Remote address is local"
 
     with mock.patch("app.common.local.request") as m_request:
+        m_request.host = "localhost:5000"
+        assert check_if_local(), "Hostname is localhost"
+
+        m_request.host = "127.0.0.1:5000"
+        assert check_if_local(), "Hostname is loopback ip"
+
         m_request.host = "not localhost"
         assert not check_if_local(), "Host is not localhost"
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
<!-- You can skip this if you're fixing a typo or doing any similar minor modifications -->

### Detailed information:

In `check_if_local`, `request.host` would usually be "localhost:5000" or "127.0.0.1:5000", so the existing comparison to "localhost" would always be false. This PR splits the hostname from the port, and checks the hostname instead.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Closing issues: 

List all issues the pull request solve: 

- Closes #349

<!-- Put `closes #XXXX` in your commit message to auto-close the issue that your PR fixes. -->

### Test plan (required)

<!-- Check all steps below and mark completed -->

- [x] The PR contains new PyTest unit/integration tests for any function or functional added. 
- [x] The PR changes existing PyTest unit/integration tests to keep all tests up to date.
- [x] The PR does not lead to degradation in unit test coverage.
- [x] Project parts affected by changes in this PR was tested manually on your local (using Postman or in any other way). List everything you've tested below:
  - pytest passes
  - Also tested with script mentioned in #349

<!-- Make sure tests pass on Circle CI. -->


