### PR TITLE
Use localhost for base_frontend_url in tests

### DIFF
--- a/app/auth/tests/test_auth_routes.py
+++ b/app/auth/tests/test_auth_routes.py
@@ -13,7 +13,7 @@ def test_register_sends_welcome_email(sendgrid_mock, client):
     assert_email_sent(
         sendgrid_mock,
         subject_starts_with="Welcome",
-        base_frontend_url="https://app.climatemind.org",
+        base_frontend_url="http://localhost:3000",
     )
 
 

--- a/app/conversations/tests/test_conversations_routes.py
+++ b/app/conversations/tests/test_conversations_routes.py
@@ -213,7 +213,7 @@ def test_consent_sends_user_b_shared_email(sendgrid_mock, client_with_user_and_h
     assert_email_sent(
         sendgrid_mock,
         subject_starts_with="Ready for a climate conversation",
-        base_frontend_url="https://app.climatemind.org",
+        base_frontend_url="http://localhost:3000",
     )
 
 

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -46,7 +46,7 @@ def test_password_reset_expired_property():
 
 def test_password_reset_url_with_default_url():
     password_reset = PasswordResetLinkFactory()
-    assert password_reset.reset_url.startswith("https://app.climatemind.org")
+    assert password_reset.reset_url.startswith("http://localhost:3000")
 
 
 @mock.patch("app.models.current_app")

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -44,11 +44,6 @@ def test_password_reset_expired_property():
     assert not password_reset.expired, "PasswordResetLink should not be expired"
 
 
-def test_password_reset_url_with_default_url():
-    password_reset = PasswordResetLinkFactory()
-    assert password_reset.reset_url.startswith("http://localhost:3000")
-
-
 @mock.patch("app.models.current_app")
 def test_password_reset_url_with_configured_base_frontend_url(m_current_app):
     m_current_app.config.get.side_effect = (

--- a/docker/docker-compose.pytest.yml
+++ b/docker/docker-compose.pytest.yml
@@ -13,6 +13,7 @@ services:
       TEST_DATABASE_PARAMS: Driver={ODBC Driver 17 for SQL Server};Server=tcp:db,1433;Uid=sa;Pwd=Cl1mat3m1nd!;Encrypt=no;TrustServerCertificate=no;Connection Timeout=30;
       RECAPTCHA_SECRET_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
       FLASK_APP: "climatemind.py"
+      BASE_FRONTEND_URL: "http://localhost:3000"
     stdin_open: true
     tty: true
     links:


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
<!-- You can skip this if you're fixing a typo or doing any similar minor modifications -->

### Detailed information:

In ec87a78358d9e70b92e95d81cd633b1ecc277f51, we configured the local docker compose file to use locahost:3000 as the base_frontend_url. This breaks tests locally, since the tests expect the base_frontend_url to be app.climatemind.org.

This changes the tests to conform to localhost:3000, and it also changes `docker-compose.pytest.yml` so that it uses localhost in CI as well.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)

<!-- Check all steps below and mark completed -->

- [x] The PR contains new PyTest unit/integration tests for any function or functional added. 
- [x] The PR changes existing PyTest unit/integration tests to keep all tests up to date.
- [x] The PR does not lead to degradation in unit test coverage.
- [x] Project parts affected by changes in this PR was tested manually on your local (using Postman or in any other way). List everything you've tested below:
  - Ran all pytests

<!-- Make sure tests pass on Circle CI. -->


