### PR TITLE
Skip Recaptcha Validation for Native Apps

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -76,7 +76,7 @@ def login():
     if not user or not user.check_password(password):
         raise UnauthorizedError(message="Wrong email or password. Try again.")
 
-    if not check_if_local() and not r.get("skip_captcha", None):
+    if not check_if_local() and not r.get("skipCaptcha", None):
         # Verify captcha with Google
         secret_key = os.environ.get("RECAPTCHA_SECRET_KEY")
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from flask import request, jsonify, make_response
 from app.auth import bp
 from app.auth.validators import password_valid

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -76,7 +76,7 @@ def login():
     if not user or not user.check_password(password):
         raise UnauthorizedError(message="Wrong email or password. Try again.")
 
-    if not check_if_local():
+    if not check_if_local() and not r.get("skip_captcha", None):
         # Verify captcha with Google
         secret_key = os.environ.get("RECAPTCHA_SECRET_KEY")
 


### PR DESCRIPTION
The Recaptcha is a good method for the website to counter scripting / bots. However, for our native apps on Android and iOS we don't like to have the Recaptcha. An optional skip_recaptcha parameter in the body allows to bypass the validation. Of course this is not an optimal solution, but for my estimation it is sufficiently for a small user base like we have it currently. As all the source code is open sourced, security plays an important role and we will improve it consistently.