### PR TITLE
528 refactor google auth to use response only

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -403,14 +403,14 @@ def logout():
 
 def create_tokens_and_set_params(user, email, access_token, refresh_token, user_b=None):
     """
-    Creates access and refresh tokens and sets them as cookies.
-    Also sets user details as cookies and redirects to a specific URL.
+    Creates access and refresh tokens and sets them as params in url.
+    Redirects to a specific URL.
     Sends a token to the client and which then sends this back and exchanges the email token for the user's email.
 
 
     Parameters:
     - user: User object containing user details (e.g., user.first_name, user.last_name, etc.)
-    - email: User's email address (used to set the email cookie)
+    - email: User's email address (used to set the email in the param)
     - access_token: Access token generated for the user
     - refresh_token: Refresh token generated for the user
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -375,15 +375,34 @@ def create_tokens_and_set_cookies(user, email, access_token, refresh_token, user
         response = make_response(
             redirect(f'{base_frontend_url}/login/{user_b}?access_token={access_token}&refresh_token={refresh_token}&message={message}'))
     else:
-        response = make_response(redirect(
-            f'{base_frontend_url}/login?access_token={access_token}&refresh_token={refresh_token}'))
-    response.set_cookie("first_name", user.first_name, secure=True)
-    response.set_cookie("last_name", user.last_name, secure=True)
-    response.set_cookie("user_uuid", user.user_uuid, secure=True)
-    response.set_cookie("quiz_id", user.quiz_uuid, secure=True)
-    response.set_cookie("user_email", email, secure=True)
-    response.set_cookie("refresh_token", refresh_token,
-                        path="/refresh", httponly=True)
+        #     response = make_response(redirect(
+        #         f'{base_frontend_url}/login?access_token={access_token}&refresh_token={refresh_token}'))
+        # response.set_cookie("first_name", user.first_name, secure=True)
+        # response.set_cookie("last_name", user.last_name, secure=True)
+        # response.set_cookie("user_uuid", user.user_uuid, secure=True)
+        # response.set_cookie("quiz_id", user.quiz_uuid, secure=True)
+        # response.set_cookie("user_email", email, secure=True)
+        # response.set_cookie("refresh_token", refresh_token,
+        #                     path="/refresh", httponly=True)
+        response = make_response(
+            jsonify(
+                {
+                    "message": "Successfully created user",
+                    "access_token": access_token,
+                    "user": {
+                        "first_name": user.first_name,
+                        "last_name": user.last_name,
+                        "email": user.user_email,
+                        "user_uuid": user.user_uuid,
+                        "quiz_id": user.quiz_uuid,
+                    },
+                }
+            ),
+            201,
+            redirect(
+                f'{base_frontend_url}/login?access_token={access_token}&refresh_token={refresh_token}')
+        )
+
     return response
 
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -254,7 +254,7 @@ def register_callback():
         access_token = create_access_token(identity=user, fresh=True)
         refresh_token = create_refresh_token(identity=user)
 
-        response = create_tokens_and_set_cookies(
+        response = create_tokens_and_set_params(
             user, email, access_token, refresh_token, user_b)
 
         send_welcome_email(user.user_email, user.first_name)
@@ -291,7 +291,7 @@ def callback():
             access_token = create_access_token(identity=user, fresh=True)
             refresh_token = create_refresh_token(identity=user)
 
-            response = create_tokens_and_set_cookies(
+            response = create_tokens_and_set_params(
                 user, email, access_token, refresh_token, user_b)
             return response
         else:
@@ -401,7 +401,7 @@ def logout():
     return response, 200
 
 
-def create_tokens_and_set_cookies(user, email, access_token, refresh_token, user_b=None):
+def create_tokens_and_set_params(user, email, access_token, refresh_token, user_b=None):
     """
     Creates access and refresh tokens and sets them as cookies.
     Also sets user details as cookies and redirects to a specific URL.


### PR DESCRIPTION
Modified the callback route to handle the creation of access tokens and params etc. 
Create a new route for the fetch request to return the response after the callback.
This included generating a token to exchange for an email address that is stored in the flask session to identify the user rather than using the email address directly in cookies which is not secure. 
Have tested this using React for Google login and it works.


Closes #528 